### PR TITLE
Replace rchardet19 gem with rchardet

### DIFF
--- a/cmxl.gemspec
+++ b/cmxl.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~>3.0'
   spec.add_development_dependency 'simplecov'
 
-  spec.add_dependency 'rchardet19'
+  spec.add_dependency 'rchardet'
 end

--- a/lib/cmxl.rb
+++ b/lib/cmxl.rb
@@ -1,6 +1,6 @@
 require 'cmxl/version'
 
-require 'rchardet19'
+require 'rchardet'
 
 require 'cmxl/field'
 require 'cmxl/statement'
@@ -31,8 +31,8 @@ module Cmxl
   def self.parse(data, options = {})
     options[:statement_separator] ||= config[:statement_separator]
     # if no encoding is provided we try to guess using CharDet
-    if options[:encoding].nil? && cd = CharDet.detect(data, silent: true)
-      options[:encoding] = cd.encoding
+    if options[:encoding].nil? && cd = CharDet.detect(data)
+      options[:encoding] = cd['encoding']
     end
 
     if options[:encoding]


### PR DESCRIPTION
Podmieniłem rchardet19 w którym występuje deprecation na rchardet które jest dalej rozwijane i w którym deprecation nie występuje.

[Odpaliłem testy intuma](https://github.com/intum/intum/pull/4404) z tą podmianką i też na zielono już bez komunikatów:
<img width="1547" alt="image" src="https://github.com/intum/cmxl/assets/42994488/87ef3b9e-5a91-416d-8e0b-a47f7b125107">


Przechodzą też testy:
<img width="815" alt="image" src="https://github.com/intum/cmxl/assets/42994488/3d5d5823-b476-4f91-9d6d-6e1f858b10b5">
